### PR TITLE
feat: write country and Metal Archives URL into TXXX tags

### DIFF
--- a/libs/album/feature-shell/src/lib/album/album.component.ts
+++ b/libs/album/feature-shell/src/lib/album/album.component.ts
@@ -326,8 +326,8 @@ export class AlbumShellComponent implements OnInit {
   }
 
   private getTrack(album: AlbumWithoutTracks, albumTrack: Track): Track {
-    const { artist, genre, year, artistUrl, albumUrl, cover } = album;
-    const track = { ...albumTrack, artist, genre, year, artistUrl, albumUrl, cover, album: album.album };
+    const { artist, genre, year, country, artistUrl, albumUrl, cover } = album;
+    const track = { ...albumTrack, artist, genre, year, country, artistUrl, albumUrl, cover, album: album.album };
     return track;
   }
 

--- a/libs/track/api/src/lib/track.service.spec.ts
+++ b/libs/track/api/src/lib/track.service.spec.ts
@@ -1,0 +1,72 @@
+import { TrackDto } from '@metal-p3/api-interfaces';
+import { AdbService } from '@metal-p3/shared/adb';
+import { FileSystemService } from '@metal-p3/shared/file-system';
+import * as NodeID3 from 'node-id3';
+import { TrackService } from './track.service';
+
+jest.mock('node-id3', () => ({
+  Promise: {
+    update: jest.fn().mockResolvedValue(true),
+  },
+  read: jest.fn(),
+}));
+
+describe('TrackService.saveTrack tag building', () => {
+  let service: TrackService;
+  let updateSpy: jest.Mock;
+
+  const baseTrack: TrackDto = {
+    id: 1,
+    fullPath: '/music/test.mp3',
+    folder: '/music',
+    file: 'test.mp3',
+    trackNumber: '01',
+    title: 'Test Title',
+    artist: 'Test Artist',
+    album: 'Test Album',
+    year: 2024,
+    genre: 'Metal',
+  } as TrackDto;
+
+  beforeEach(() => {
+    const fileSystem = { setReadAndWritePermission: jest.fn() } as unknown as FileSystemService;
+    const adb = {} as AdbService;
+    service = new TrackService(fileSystem, adb);
+    updateSpy = (NodeID3.Promise.update as jest.Mock).mockClear().mockResolvedValue(true);
+  });
+
+  it('writes only COUNTRY when only country is set', async () => {
+    await service.saveTrack({ ...baseTrack, country: 'Sweden' });
+
+    const tags = updateSpy.mock.calls[0][0];
+    expect(tags.userDefinedText).toEqual([{ description: 'COUNTRY', value: 'Sweden' }]);
+    expect(tags.comment).toBeUndefined();
+  });
+
+  it('writes only METAL_ARCHIVES_URL when only albumUrl is set', async () => {
+    await service.saveTrack({ ...baseTrack, albumUrl: 'https://metal-archives.com/albums/foo' });
+
+    const tags = updateSpy.mock.calls[0][0];
+    expect(tags.userDefinedText).toEqual([{ description: 'METAL_ARCHIVES_URL', value: 'https://metal-archives.com/albums/foo' }]);
+    expect(tags.comment).toBeUndefined();
+  });
+
+  it('writes both COUNTRY and METAL_ARCHIVES_URL in a single userDefinedText array', async () => {
+    await service.saveTrack({ ...baseTrack, country: 'Sweden', albumUrl: 'https://metal-archives.com/albums/foo' });
+
+    const tags = updateSpy.mock.calls[0][0];
+    expect(tags.userDefinedText).toEqual([
+      { description: 'COUNTRY', value: 'Sweden' },
+      { description: 'METAL_ARCHIVES_URL', value: 'https://metal-archives.com/albums/foo' },
+    ]);
+    expect(tags.comment).toBeUndefined();
+  });
+
+  it('omits userDefinedText when neither country nor albumUrl is set', async () => {
+    await service.saveTrack(baseTrack);
+
+    const tags = updateSpy.mock.calls[0][0];
+    expect(tags.userDefinedText).toBeUndefined();
+    expect(tags.comment).toBeUndefined();
+  });
+});

--- a/libs/track/api/src/lib/track.service.ts
+++ b/libs/track/api/src/lib/track.service.ts
@@ -87,8 +87,15 @@ export class TrackService {
       genre: track.genre,
     };
 
+    const userDefinedText: NonNullable<NodeID3.Tags['userDefinedText']> = [];
+    if (track.country) {
+      userDefinedText.push({ description: 'COUNTRY', value: track.country });
+    }
     if (track.albumUrl) {
-      baseTags = { ...baseTags, comment: { language: 'eng', text: track.albumUrl } };
+      userDefinedText.push({ description: 'METAL_ARCHIVES_URL', value: track.albumUrl });
+    }
+    if (userDefinedText.length) {
+      baseTags = { ...baseTags, userDefinedText };
     }
 
     if (track.lyrics) {


### PR DESCRIPTION
## Summary
- Replace the COMM-frame hack for the album URL with two user-defined TXXX frames (`COUNTRY`, `METAL_ARCHIVES_URL`) so the Android mobile app can extract both fields by description
- Pull `country` through the album-shell `getTrack` mapper so the value reaches `TrackService.saveTrack`
- New `track.service.spec.ts` asserts the exact `userDefinedText` payload sent to `NodeID3.Promise.update` for all four combinations (country only, albumUrl only, both, neither)

## Test plan
- [x] `track-api` jest: 4/4 pass
- [x] `album-feature-shell` jest: 5/5 pass (no regressions)
- [x] `tsc --noEmit` clean for both libs
- [x] `eslint` clean for changed files
- [ ] On a real album save, confirm Android reads both `COUNTRY` and `METAL_ARCHIVES_URL` from the written file