### PR TITLE
feat: propagate album metadata to track ID3 on add

### DIFF
--- a/libs/album/api/src/lib/album.service.ts
+++ b/libs/album/api/src/lib/album.service.ts
@@ -290,9 +290,52 @@ export class AlbumService {
     // Step 1: Read ID3 tags and resolve (or create) the band record.
     // Step 2: Search Metal Archives for URLs, then persist the album.
     // Step 3: Rename the folder and individual track files to a canonical format.
+    // Step 4: Propagate album-level Metal Archives metadata (country / albumUrl) into each track's ID3.
     return this.prepareTagsAndBand(folder, dirName).pipe(
       concatMap(({ tags, band }) => this.searchAndCreateAlbum(folder, tags, band)),
       concatMap((albumDto) => this.renameFolderAndTracks(albumDto)),
+      concatMap((albumDto) => this.propagateAlbumMetadataToTracks(albumDto)),
+    );
+  }
+
+  private propagateAlbumMetadataToTracks(albumDto: AlbumDto): Observable<AlbumDto> {
+    if (!albumDto.country && !albumDto.albumUrl) {
+      return of(albumDto);
+    }
+
+    let files: string[];
+    try {
+      files = this.fileSystemService
+        .getFiles(albumDto.fullPath)
+        .filter((f) => path.extname(f) === '.mp3')
+        .map((f) => path.join(albumDto.fullPath, f));
+    } catch (error) {
+      Logger.error(`Failed to list files for track metadata propagation in "${albumDto.fullPath}": ${error}`);
+      return of(albumDto);
+    }
+
+    if (!files.length) {
+      return of(albumDto);
+    }
+
+    return this.trackService.getTracks(files).pipe(
+      concatMap((tracks) => {
+        const enriched = tracks.map((track) => ({
+          ...track,
+          artist: albumDto.artist ?? track.artist,
+          album: albumDto.album ?? track.album,
+          year: albumDto.year ?? track.year,
+          genre: albumDto.genre ?? track.genre,
+          country: albumDto.country ?? track.country,
+          albumUrl: albumDto.albumUrl ?? track.albumUrl,
+          artistUrl: albumDto.artistUrl ?? track.artistUrl,
+        }));
+        return from(this.trackService.saveTracks(enriched)).pipe(map(() => albumDto));
+      }),
+      catchError((error) => {
+        Logger.error(`Failed to propagate album metadata to tracks for album ${albumDto.id}: ${error}`);
+        return of(albumDto);
+      }),
     );
   }
 


### PR DESCRIPTION
## Summary
- After the file watcher adds a new album and `searchAndCreateAlbum` resolves the Metal Archives URL and band country, write those values (plus artist/album/year/genre/artistUrl) into every track's ID3 so the TXXX `COUNTRY` and `METAL_ARCHIVES_URL` frames added in #2 are populated for newly-added albums, not just edited ones.
- New `propagateAlbumMetadataToTracks` step appended to the `addAlbum` Observable pipeline. No new public API surface; `TrackService.saveTracks` is unchanged.
- No-op when both `country` and `albumUrl` are absent. Failures are caught + logged so the watcher's gateway message and `pendingFolders` cleanup still run.

## Test plan
- [ ] `tsc --noEmit` clean for `album-api`, `track-api`, `api` (verified locally)
- [ ] Drop a new artist/album folder under the configured `BASE_PATH`; confirm logs show MA URL + country resolved, then inspect resulting `.mp3` files and confirm TXXX `COUNTRY` and `METAL_ARCHIVES_URL` frames are present